### PR TITLE
Added core public functions for asset registration, dividend claiming and governance proposal with voting logic in StacksTokenize

### DIFF
--- a/contracts/StacksTokenize.clar
+++ b/contracts/StacksTokenize.clar
@@ -121,3 +121,195 @@
         (<= (- expiry stacks-block-height) MAX-EXPIRY)
     )
 )
+
+
+
+(define-private (validate-minimum-votes (vote-count uint))
+    (and 
+        (> vote-count u0)
+        (<= vote-count tokens-per-asset)
+    )
+)
+
+(define-private (validate-metadata-uri (uri (string-ascii 256)))
+    (and 
+        (> (len uri) u0)
+        (<= (len uri) u256)
+    )
+)
+
+(define-public (register-asset 
+    (metadata-uri (string-ascii 256)) 
+    (asset-value uint))
+    (begin
+        (asserts! (is-eq tx-sender contract-owner) err-owner-only)
+        (asserts! (validate-metadata-uri metadata-uri) err-invalid-uri)
+        (asserts! (validate-asset-value asset-value) err-invalid-value)
+
+        (let 
+            ((asset-id (get-next-asset-id)))
+            (map-set assets
+                { asset-id: asset-id }
+                {
+                    owner: contract-owner,
+                    metadata-uri: metadata-uri,
+                    asset-value: asset-value,
+                    is-locked: false,
+                    creation-height: stacks-block-height,
+                    last-price-update: stacks-block-height,
+                    total-dividends: u0
+                }
+            )
+            (map-set token-balances
+                { owner: contract-owner, asset-id: asset-id }
+                { balance: tokens-per-asset }
+            )
+            (ok asset-id)
+        )
+    )
+)
+
+
+
+(define-public (claim-dividends (asset-id uint))
+    (let
+        (
+            (asset (unwrap! (get-asset-info asset-id) err-not-found))
+            (balance (get-balance tx-sender asset-id))
+            (last-claim (get-last-claim asset-id tx-sender))
+            (total-dividends (get total-dividends asset))
+            (claimable-amount (/ (* balance (- total-dividends last-claim)) tokens-per-asset))
+        )
+        (asserts! (> claimable-amount u0) err-invalid-amount)
+        (ok (map-set dividend-claims
+            { asset-id: asset-id, claimer: tx-sender }
+            { last-claimed-amount: total-dividends }
+        ))
+    )
+)
+
+(define-public (create-proposal 
+    (asset-id uint)
+    (title (string-ascii 256))
+    (duration uint)
+    (minimum-votes uint))
+    (begin
+        (asserts! (validate-duration duration) err-invalid-duration)
+        (asserts! (validate-minimum-votes minimum-votes) err-invalid-votes)
+        (asserts! (validate-metadata-uri title) err-invalid-title)
+        (asserts! (>= (get-balance tx-sender asset-id) (/ tokens-per-asset u10)) err-not-authorized)
+
+        (let
+            ((proposal-id (get-next-proposal-id)))
+            (ok (map-set proposals
+                { proposal-id: proposal-id }
+                {
+                    title: title,
+                    asset-id: asset-id,
+                    start-height: stacks-block-height,
+                    end-height: (+ stacks-block-height duration),
+                    executed: false,
+                    votes-for: u0,
+                    votes-against: u0,
+                    minimum-votes: minimum-votes
+                }
+            ))
+        )
+    )
+)
+
+(define-public (vote 
+    (proposal-id uint)
+    (vote-for bool)
+    (amount uint))
+    (let
+        (
+            (proposal (unwrap! (get-proposal proposal-id) err-not-found))
+            (asset-id (get asset-id proposal))
+            (balance (get-balance tx-sender asset-id))
+        )
+        (begin
+            (asserts! (>= balance amount) err-invalid-amount)
+            (asserts! (< stacks-block-height (get end-height proposal)) err-vote-ended)
+            (asserts! (is-none (get-vote proposal-id tx-sender)) err-vote-exists)
+
+            (map-set votes
+                { proposal-id: proposal-id, voter: tx-sender }
+                { vote-amount: amount }
+            )
+            (ok (map-set proposals
+                { proposal-id: proposal-id }
+                (merge proposal
+                    {
+                        votes-for: (if vote-for
+                            (+ (get votes-for proposal) amount)
+                            (get votes-for proposal)
+                        ),
+                        votes-against: (if vote-for
+                            (get votes-against proposal)
+                            (+ (get votes-against proposal) amount)
+                        )
+                    }
+                ))
+            )
+        )
+    )
+)
+
+;; Read Functions
+(define-read-only (get-asset-info (asset-id uint))
+    (map-get? assets { asset-id: asset-id })
+)
+
+(define-read-only (get-balance (owner principal) (asset-id uint))
+    (default-to u0
+        (get balance
+            (map-get? token-balances
+                { owner: owner, asset-id: asset-id }
+            )
+        )
+    )
+)
+
+(define-read-only (get-proposal (proposal-id uint))
+    (map-get? proposals { proposal-id: proposal-id })
+)
+
+(define-read-only (get-vote (proposal-id uint) (voter principal))
+    (map-get? votes { proposal-id: proposal-id, voter: voter })
+)
+
+(define-read-only (get-price-feed (asset-id uint))
+    (map-get? price-feeds { asset-id: asset-id })
+)
+
+(define-read-only (get-last-claim (asset-id uint) (claimer principal))
+    (default-to u0
+        (get last-claimed-amount
+            (map-get? dividend-claims
+                { asset-id: asset-id, claimer: claimer }
+            )
+        )
+    )
+)
+
+;; Private Functions
+(define-private (get-next-asset-id)
+    (default-to u1
+        (get-last-asset-id)
+    )
+)
+
+(define-private (get-next-proposal-id)
+    (default-to u1
+        (get-last-proposal-id)
+    )
+)
+
+(define-private (get-last-asset-id)
+    none
+)
+
+(define-private (get-last-proposal-id)
+    none
+)


### PR DESCRIPTION

## 🚀 Pull Request: Add Core Public Functions for Asset Lifecycle and Governance in `StacksTokenize`

###  Summary

This pull request introduces the core **public-facing functions** for the `StacksTokenize` smart contract. These include functionality for registering real-world assets, distributing dividends to token holders, creating governance proposals, and voting on them. The PR also includes input validation, read-only accessors, and ID generation placeholders.

---

### ✅ What’s Included

#### 📌 Asset Registration
- **Function:** `register-asset(metadata-uri, asset-value)`
- Registers a new asset and mints `tokens-per-asset` SFTs (100,000) to the `contract-owner`.
- Performs validation on:
  - Metadata URI
  - Asset value range
- Automatically sets timestamps (`stacks-block-height`) and initial state flags.

---

#### 💰 Dividend Claiming
- **Function:** `claim-dividends(asset-id)`
- Enables token holders to claim proportional dividends based on their token balance.
- Ensures:
  - Holder has a positive claimable amount
  - Claims are tracked via `dividend-claims` to prevent reclaims

---

#### 🗳 Proposal Creation
- **Function:** `create-proposal(asset-id, title, duration, minimum-votes)`
- Allows holders with ≥10% token stake in an asset to propose decisions.
- Validates:
  - Title format
  - Duration is within acceptable bounds
  - Minimum vote count is within token range
- Initializes `votes-for`, `votes-against`, and sets voting period using `stacks-block-height`.

---

#### 🗳 Proposal Voting
- **Function:** `vote(proposal-id, vote-for, amount)`
- Token holders can cast a vote for or against a proposal using their asset tokens.
- Restrictions:
  - Can only vote once per proposal
  - Voting must occur before `end-height`
  - Must have enough tokens

---

#### 🔍 Read-Only Functions
- `get-asset-info`, `get-balance`, `get-proposal`, `get-vote`, `get-price-feed`, `get-last-claim`
- Exposes structured data to frontends/dApps for building UIs

---

#### 🔧 Private Utilities
- `get-next-asset-id`, `get-next-proposal-id`: Currently return `u1` (placeholder)
- `get-last-asset-id`, `get-last-proposal-id`: Return `none` (to be implemented in future PR)
- Input validation for:
  - `validate-metadata-uri`
  - `validate-minimum-votes`

---